### PR TITLE
Feature: iOS Push Notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "@nestjs/platform-express": "^8.2.6",
                 "@nestjs/throttler": "^2.0.0",
                 "@nestjs/typeorm": "^8.0.3",
+                "@parse/node-apn": "^5.1.3",
                 "bcrypt": "^5.0.1",
                 "class-transformer": "^0.5.1",
                 "class-validator": "^0.13.2",
@@ -1756,6 +1757,20 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/@parse/node-apn": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-5.1.3.tgz",
+            "integrity": "sha512-Bwhmbm895lEIF2772PJ8dSvBjrtOG9/q/TDMxmX40IgZxQFoXS73+JUIKTq3CA7SUB/Szu5roJINQ0L2U/1MJw==",
+            "dependencies": {
+                "debug": "4.3.3",
+                "jsonwebtoken": "8.5.1",
+                "node-forge": "1.3.0",
+                "verror": "1.10.1"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/@selderee/plugin-htmlparser2": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
@@ -3004,6 +3019,14 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
             "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw=="
+        },
+        "node_modules/assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "engines": {
+                "node": ">=0.8"
+            }
         },
         "node_modules/assign-symbols": {
             "version": "1.0.0",
@@ -5618,6 +5641,14 @@
                 "list-stylesheets": "^1.2.9",
                 "style-data": "^1.4.7"
             }
+        },
+        "node_modules/extsprintf": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+            "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+            "engines": [
+                "node >=0.6.0"
+            ]
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -9107,6 +9138,14 @@
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
+            }
+        },
+        "node_modules/node-forge": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.0.tgz",
+            "integrity": "sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA==",
+            "engines": {
+                "node": ">= 6.13.0"
             }
         },
         "node_modules/node-int64": {
@@ -13102,6 +13141,19 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/verror": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+            "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+            "dependencies": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=0.6.0"
+            }
+        },
         "node_modules/void-elements": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -14892,6 +14944,17 @@
                 }
             }
         },
+        "@parse/node-apn": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-5.1.3.tgz",
+            "integrity": "sha512-Bwhmbm895lEIF2772PJ8dSvBjrtOG9/q/TDMxmX40IgZxQFoXS73+JUIKTq3CA7SUB/Szu5roJINQ0L2U/1MJw==",
+            "requires": {
+                "debug": "4.3.3",
+                "jsonwebtoken": "8.5.1",
+                "node-forge": "1.3.0",
+                "verror": "1.10.1"
+            }
+        },
         "@selderee/plugin-htmlparser2": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
@@ -15951,6 +16014,11 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
             "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw=="
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "assign-symbols": {
             "version": "1.0.0",
@@ -17985,6 +18053,11 @@
                 "list-stylesheets": "^1.2.9",
                 "style-data": "^1.4.7"
             }
+        },
+        "extsprintf": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+            "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -20716,6 +20789,11 @@
                     }
                 }
             }
+        },
+        "node-forge": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.0.tgz",
+            "integrity": "sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA=="
         },
         "node-int64": {
             "version": "0.4.0",
@@ -23733,6 +23811,16 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+        },
+        "verror": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+            "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
         },
         "void-elements": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "test:watch": "jest --watch",
         "test:cov": "jest --coverage",
         "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-        "test:e2e": "jest --config ./test/jest-e2e.json"
+        "test:e2e": "jest --config ./test/jest-e2e.json",
+        "typeorm:migrate:gen": "typeorm migration:generate -n"
     },
     "dependencies": {
         "@casl/ability": "^5.4.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@nestjs/platform-express": "^8.2.6",
         "@nestjs/throttler": "^2.0.0",
         "@nestjs/typeorm": "^8.0.3",
+        "@parse/node-apn": "^5.1.3",
         "bcrypt": "^5.0.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.13.2",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,6 +31,8 @@ import { RouterModule } from "nest-router";
             password: variables.database.password,
             database: variables.database.name,
             entities: [User, Session, Payment],
+            migrations: [`${__dirname}/../migrations/*`],
+            migrationsRun: true,
             // synchronize: true,
         }),
         ThrottlerModule.forRoot({

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
 import { AuthService, ValidatedUserReturnType } from "@moneyboy/auth/auth.service";
 import { LocalAuthGuard } from "@moneyboy/auth/guards/local-auth.guard";
 import { Public } from "@moneyboy/auth/guards/public.guard";
+import { UserLoginDTOImpl } from "@moneyboy/auth/types/loginDTO.impl";
 import { RefreshTokenDTOImpl } from "@moneyboy/auth/types/refreshTokenDTO.impl";
 import { UserRegisterDTOImpl } from "@moneyboy/auth/types/userRegisterDTO.impl";
 import {
@@ -32,10 +33,10 @@ export class AuthController {
     @UseGuards(LocalAuthGuard)
     @Throttle()
     @Post("login")
-    public async login(@Req() req: Request) {
+    public async login(@Req() req: Request, @Body() { notificationToken }: UserLoginDTOImpl) {
         // in this case, the req.user property is actually not of type ISession, but
         // just contains a field `id`, which holds the id of the already authenticated user.
-        return this.authService.login(req.user as ValidatedUserReturnType);
+        return this.authService.login(req.user as ValidatedUserReturnType, notificationToken);
     }
 
     @Public()

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -19,6 +19,7 @@ const dummyUser: IUser = {
     emailVerified: true,
     password: hashSync(dummyPassword, 10),
     username: "dummyUser",
+    sessions: [],
 };
 const dummySessionId = uuid();
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -47,8 +47,8 @@ export class AuthService {
     /**
      * Log a user in and return the access token for this user.
      */
-    public async login(user: ValidatedUserReturnType) {
-        const sessionId = await this.sessionService.createSession(user.id);
+    public async login(user: ValidatedUserReturnType, notificationToken?: string) {
+        const sessionId = await this.sessionService.createSession(user.id, notificationToken);
         const payload: JWTToken = { sub: sessionId };
 
         return {

--- a/src/auth/strategies/jwt.strategy.spec.ts
+++ b/src/auth/strategies/jwt.strategy.spec.ts
@@ -15,6 +15,7 @@ const dummyUser: IUser = {
     emailVerified: true,
     password: hashSync(dummyPassword, 10),
     username: "dummyUser",
+    sessions: [],
 };
 const dummySession: ISession = {
     id: uuid(),

--- a/src/auth/types/loginDTO.impl.ts
+++ b/src/auth/types/loginDTO.impl.ts
@@ -1,0 +1,12 @@
+import { UserLoginDTO } from "@moneyboy/interfaces/user";
+import { IsOptional, IsString } from "class-validator";
+
+export class UserLoginDTOImpl implements UserLoginDTO {
+    @IsString()
+    username!: string;
+    @IsString()
+    password!: string;
+    @IsString()
+    @IsOptional()
+    notificationToken?: string;
+}

--- a/src/casl/casl-ability.factory.spec.ts
+++ b/src/casl/casl-ability.factory.spec.ts
@@ -14,6 +14,7 @@ const issueUser: IUser = {
     emailVerified: true,
     password: hashSync("dummyPassword", 10),
     username: "dummyUser",
+    sessions: [],
 };
 
 const targetUser: IUser = {
@@ -23,6 +24,7 @@ const targetUser: IUser = {
     emailVerified: true,
     password: hashSync("otherPassword", 10),
     username: "otherUser",
+    sessions: [],
 };
 
 const thirdUser: IUser = {
@@ -32,6 +34,7 @@ const thirdUser: IUser = {
     emailVerified: true,
     password: hashSync("thirdPassword", 10),
     username: "thirdUser",
+    sessions: [],
 };
 
 const dummyPayment: Payment = Payment.fromData({

--- a/src/config/variables.ts
+++ b/src/config/variables.ts
@@ -31,6 +31,6 @@ export default {
         key: process.env.APNS_KEY ?? "",
         keyId: process.env.APNS_KEY_ID ?? "",
         teamId: process.env.APNS_TEAM_ID ?? "",
-        topci: process.env.APNS_TOPIC ?? "",
+        topic: process.env.APNS_TOPIC ?? "",
     },
 };

--- a/src/config/variables.ts
+++ b/src/config/variables.ts
@@ -27,4 +27,10 @@ export default {
             pass: process.env.SMTP_PASS ?? "SMTP_PASS",
         },
     },
+    notifications: {
+        key: process.env.APNS_KEY ?? "",
+        keyId: process.env.APNS_KEY_ID ?? "",
+        teamId: process.env.APNS_TEAM_ID ?? "",
+        topci: process.env.APNS_TOPIC ?? "",
+    },
 };

--- a/src/interfaces/session.d.ts
+++ b/src/interfaces/session.d.ts
@@ -14,6 +14,11 @@ export interface ISession {
      * User associated with this session.
      */
     user: IUser;
+
+    /**
+     * Notification token associated with this session.
+     */
+    notificationToken?: string;
     /**
      * Date of creation of this session.
      */

--- a/src/interfaces/user.d.ts
+++ b/src/interfaces/user.d.ts
@@ -1,3 +1,5 @@
+import { Session } from "@moneyboy/models/session";
+
 /**
  * Data send during registration of a new user.
  *
@@ -8,6 +10,12 @@ export interface UserRegisterDTO {
     displayName: string;
     password: string;
     email: string;
+}
+
+export interface UserLoginDTO {
+    username: string;
+    password: string;
+    notificationToken?: string;
 }
 
 /**
@@ -41,4 +49,9 @@ export interface IUser {
      * Flag for indicating, that a user verified their email.
      */
     emailVerified: boolean;
+
+    /**
+     * Sessions for this user
+     */
+    sessions: Session[];
 }

--- a/src/migrations/1649603075208-Migrations.ts
+++ b/src/migrations/1649603075208-Migrations.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Migrations1649603075208 implements MigrationInterface {
+    name = "Migrations1649603075208";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`session\` ADD \`notificationToken\` varchar(255) NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`session\` DROP COLUMN \`notificationToken\``);
+    }
+}

--- a/src/migrations/1649604348715-Migrations.ts
+++ b/src/migrations/1649604348715-Migrations.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Migrations1649604348715 implements MigrationInterface {
+    name = "Migrations1649604348715";
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `ALTER TABLE \`session\` ADD UNIQUE INDEX \`IDX_ba49e7d24851680c5833c65d68\` (\`notificationToken\`)`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`session\` DROP INDEX \`IDX_ba49e7d24851680c5833c65d68\``);
+    }
+}

--- a/src/models/payment.spec.ts
+++ b/src/models/payment.spec.ts
@@ -16,6 +16,7 @@ describe("Payment", () => {
             emailVerified: true,
             password: hashSync("dummyPassword", 10),
             username: "dummyUser",
+            sessions: [],
         };
         const targetUser: IUser = {
             id: uuid(),
@@ -24,6 +25,7 @@ describe("Payment", () => {
             emailVerified: true,
             password: hashSync("otherPassword", 10),
             username: "otherUser",
+            sessions: [],
         };
         const dummyPayment: Payment = Payment.fromData({
             id: uuid(),

--- a/src/models/session.spec.ts
+++ b/src/models/session.spec.ts
@@ -17,6 +17,7 @@ describe("Session", () => {
             emailVerified: true,
             password: hashSync("dummyPassword", 10),
             username: "dummyUser",
+            sessions: [],
         };
 
         const dummySession: ISession = {
@@ -24,6 +25,8 @@ describe("Session", () => {
             createdAt: Date.now(),
             user: dummyUser,
         };
+        dummyUser.sessions.push(dummySession);
+
         expect(Session.fromData(dummySession)).toEqual(dummySession);
     });
 });

--- a/src/models/session.ts
+++ b/src/models/session.ts
@@ -16,6 +16,13 @@ export class Session implements ISession {
     @JoinColumn()
     user!: User;
 
+    @Column("varchar", {
+        length: 255,
+        nullable: true,
+        unique: true,
+    })
+    notificationToken?: string;
+
     @Column("bigint")
     createdAt!: number;
 

--- a/src/models/user.spec.ts
+++ b/src/models/user.spec.ts
@@ -16,6 +16,7 @@ describe("User", () => {
             emailVerified: true,
             password: hashSync("dummyPassword", 10),
             username: "dummyUser",
+            sessions: [],
         };
         expect(User.fromData(dummyUser)).toEqual(dummyUser);
     });

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,6 +1,7 @@
 import { IUser } from "@moneyboy/interfaces/user";
+import { Session } from "@moneyboy/models/session";
 import { Exclude, Expose } from "class-transformer";
-import { Column, Entity, PrimaryColumn } from "typeorm";
+import { Column, Entity, JoinColumn, OneToMany, PrimaryColumn } from "typeorm";
 
 /**
  * Implementation of a user, which is coupled to a database schema.
@@ -47,6 +48,10 @@ export class User implements IUser {
         default: false,
     })
     public emailVerified!: boolean;
+
+    @OneToMany(() => Session, session => session.user)
+    @JoinColumn()
+    public sessions!: Session[];
 
     /**
      * Create a new User instance from the given data.

--- a/src/notification/notification.module.ts
+++ b/src/notification/notification.module.ts
@@ -1,0 +1,8 @@
+import { NotificationService } from "@moneyboy/notification/notification.service";
+import { Module } from "@nestjs/common";
+
+@Module({
+    providers: [NotificationService],
+    exports: [NotificationService],
+})
+export class NotificationModule {}

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -1,0 +1,24 @@
+import variables from "@moneyboy/config/variables";
+import { Injectable } from "@nestjs/common";
+import { Notification, Provider, Responses } from "@parse/node-apn";
+
+@Injectable()
+export class NotificationService {
+    private provider: Provider;
+
+    constructor() {
+        this.provider = new Provider({
+            token: {
+                key: variables.notifications.key,
+                keyId: variables.notifications.keyId,
+                teamId: variables.notifications.teamId,
+            },
+            // TODO: set this to true
+            production: false,
+        });
+    }
+
+    public async send(notification: Notification, recepients: string | string[]): Promise<Responses> {
+        return this.provider.send(notification, recepients);
+    }
+}

--- a/src/payment/payment.module.ts
+++ b/src/payment/payment.module.ts
@@ -1,5 +1,6 @@
 import { CaslModule } from "@moneyboy/casl/casl.module";
 import { Payment } from "@moneyboy/models/payment";
+import { NotificationModule } from "@moneyboy/notification/notification.module";
 import { PaymentController } from "@moneyboy/payment/payment.controller";
 import { PaymentService } from "@moneyboy/payment/payment.service";
 import { UserModule } from "@moneyboy/user/user.module";
@@ -14,6 +15,6 @@ import { TypeOrmModule } from "@nestjs/typeorm";
 @Module({
     providers: [PaymentService],
     controllers: [PaymentController],
-    imports: [TypeOrmModule.forFeature([Payment]), UserModule, CaslModule],
+    imports: [TypeOrmModule.forFeature([Payment]), UserModule, CaslModule, NotificationModule],
 })
 export class PaymentModule {}

--- a/src/payment/payment.service.spec.ts
+++ b/src/payment/payment.service.spec.ts
@@ -16,6 +16,7 @@ const dummyUsers: IUser[] = [
         emailVerified: true,
         password: hashSync("dummyPassword", 10),
         username: "dummyUser",
+        sessions: [],
     },
     {
         id: uuid(),
@@ -24,6 +25,7 @@ const dummyUsers: IUser[] = [
         emailVerified: true,
         password: hashSync("dummyPassword", 10),
         username: "otherUser",
+        sessions: [],
     },
 ];
 

--- a/src/payment/payment.service.spec.ts
+++ b/src/payment/payment.service.spec.ts
@@ -1,6 +1,7 @@
 import { PaymentCreateDTO, PaymentUpdateDTO } from "@moneyboy/interfaces/payment";
 import { IUser } from "@moneyboy/interfaces/user";
 import { Payment } from "@moneyboy/models/payment";
+import { NotificationService } from "@moneyboy/notification/notification.service";
 import { PaymentService } from "@moneyboy/payment/payment.service";
 import { UserService } from "@moneyboy/user/user.service";
 import { BadRequestException, NotFoundException } from "@nestjs/common";
@@ -40,14 +41,18 @@ const dummyPayment: PaymentCreateDTO = {
 
 describe("PaymentService", () => {
     let userServiceMock: UserService;
+    let notificationsService: NotificationService;
     let paymentRepoMock: Repository<Payment>;
 
     let paymentService: PaymentService;
 
     beforeEach(() => {
         userServiceMock = new (jest.createMockFromModule<any>("@moneyboy/user/user.service").UserService)();
+        notificationsService = new (jest.createMockFromModule<any>(
+            "@moneyboy/notification/notification.service",
+        ).NotificationService)();
         paymentRepoMock = new (jest.createMockFromModule<any>("typeorm").Repository)() as Repository<Payment>;
-        paymentService = new PaymentService(userServiceMock, paymentRepoMock);
+        paymentService = new PaymentService(userServiceMock, notificationsService, paymentRepoMock);
     });
 
     describe("create", () => {

--- a/src/session/session.service.spec.ts
+++ b/src/session/session.service.spec.ts
@@ -14,6 +14,7 @@ const dummySession: ISession = {
         password: "password",
         email: "test@example.com",
         emailVerified: true,
+        sessions: [],
     },
 };
 

--- a/src/session/session.service.ts
+++ b/src/session/session.service.ts
@@ -54,7 +54,7 @@ export class SessionService {
      * Get a session with the provided id.
      */
     public async getSession(sessionId: string): Promise<ISession | undefined> {
-        const relations: Keys<Session> = ["user"];
+        const relations = ["user", "user.sessions"];
         return await this.sessionRepository.findOne({
             where: {
                 id: sessionId,

--- a/src/session/session.service.ts
+++ b/src/session/session.service.ts
@@ -26,7 +26,7 @@ export class SessionService {
     /**
      * Create a new sessions for a provided userid and return the id of the newly created session.
      */
-    public async createSession(userId: string): Promise<string> {
+    public async createSession(userId: string, notificationToken?: string): Promise<string> {
         const user = await this.userService.findById(userId);
         if (!user) {
             throw new UnauthorizedException();
@@ -35,7 +35,17 @@ export class SessionService {
             id: uuid(),
             user: user as User,
             createdAt: Date.now(),
+            notificationToken,
         });
+        // delete all current sessions with the same notification token
+        const sessionsWithNotificationToken = notificationToken
+            ? await this.getSessionsForNotificationToken(notificationToken)
+            : [];
+        await Promise.all(
+            sessionsWithNotificationToken.map(({ id }) => {
+                this.destroySession(id);
+            }),
+        );
         await this.sessionRepository.save(session);
         return session.id;
     }
@@ -48,6 +58,21 @@ export class SessionService {
         return await this.sessionRepository.findOne({
             where: {
                 id: sessionId,
+            },
+            relations,
+        });
+    }
+
+    /**
+     * Get all sessions associated with a specified notification token.
+     *
+     * @param notificationToken notification token to get sessions with
+     */
+    public async getSessionsForNotificationToken(notificationToken: string): Promise<ISession[]> {
+        const relations: Keys<Session> = ["user"];
+        return await this.sessionRepository.find({
+            where: {
+                notificationToken,
             },
             relations,
         });

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -47,7 +47,6 @@ export class UserController {
     @UseInterceptors(ClassSerializerInterceptor)
     @Get("like")
     public async getLike(@Req() req: Request): Promise<IUser[]> {
-        console.log(req.query);
         return this.userService.findLike((req.query?.q as string) ?? "");
     }
 

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -15,6 +15,7 @@ const dummyUser: IUser = {
     emailVerified: true,
     password: hashSync("dummyPassword", 10),
     username: "dummyUser",
+    sessions: [],
 };
 
 const otherUser: IUser = {
@@ -24,6 +25,7 @@ const otherUser: IUser = {
     emailVerified: true,
     password: hashSync("dummyPassword2", 10),
     username: "dummyUser2",
+    sessions: [],
 };
 
 const unverifiedUser: IUser = {
@@ -33,6 +35,7 @@ const unverifiedUser: IUser = {
     emailVerified: false,
     password: hashSync("dummyPassword2", 10),
     username: "dummyUser3",
+    sessions: [],
 };
 
 const users: IUser[] = [dummyUser, otherUser, unverifiedUser];
@@ -60,7 +63,7 @@ describe("UserService", () => {
 
         it("returns only verified users", async () => {
             await userService.findAll();
-            expect(findMock).toHaveBeenCalledWith({ where: { emailVerified: true } });
+            expect(findMock).toHaveBeenCalledWith({ where: { emailVerified: true }, relations: ["sessions"] });
         });
 
         it("returns users returned by repo", () => {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -28,10 +28,12 @@ export class UserService {
     ) {}
 
     public async findAll(): Promise<IUser[]> {
+        const relations: Keys<IUser> = ["sessions"];
         const users = await this.userRepository.find({
             where: {
                 emailVerified: true,
             },
+            relations,
         });
         return users;
     }
@@ -40,10 +42,12 @@ export class UserService {
      * Find a user by its username.
      */
     public async findByName(username: string): Promise<IUser | undefined> {
+        const relations: Keys<IUser> = ["sessions"];
         return this.userRepository.findOne({
             where: {
                 username,
             },
+            relations,
         });
     }
 
@@ -54,10 +58,12 @@ export class UserService {
      * @returns list of users with common usernames
      */
     public async findLike(username: string): Promise<IUser[]> {
+        const relations: Keys<IUser> = ["sessions"];
         return this.userRepository.find({
             where: {
                 username: Like(`%${username}%`),
             },
+            relations,
         });
     }
 
@@ -65,10 +71,12 @@ export class UserService {
      * Find a user by its id.
      */
     public async findById(id: string): Promise<IUser | undefined> {
+        const relations: Keys<IUser> = ["sessions"];
         return this.userRepository.findOne({
             where: {
                 id,
             },
+            relations,
         });
     }
 
@@ -82,6 +90,7 @@ export class UserService {
                     ...userData,
                     id: uuid(),
                     emailVerified: false,
+                    sessions: [],
                 }),
             );
             return user;


### PR DESCRIPTION
Enable support for iOS push notifications via APNS (`@parse/node-apn`). Therefore, each sessions is associated with a notification token, which then gets used for sending notifications after issuing of payments. 